### PR TITLE
chore: Allow `.md` files for gauge specs

### DIFF
--- a/mapping/gaugespecParser.go
+++ b/mapping/gaugespecParser.go
@@ -114,7 +114,7 @@ func (gsp GaugeSpecParser) Parse(cfg utils.Config, sc utils.Sourcecode) []TestBa
 			return err
 		}
 
-		if fi.IsDir() || strings.Contains(path, "node_modules") || filepath.Ext(path) != ".spec" {
+		if fi.IsDir() || strings.Contains(path, "node_modules") || filepath.Ext(path) != ".spec" || filepath.Ext(path) != ".md" {
 			return nil
 		}
 


### PR DESCRIPTION
Specifications in Gauge are allowed to be either `.spec` or `.md`: https://docs.gauge.org/writing-specifications.html?os=macos&language=javascript&ide=vscode#specifications-spec